### PR TITLE
Ecarrillo - fixing minwidth issue

### DIFF
--- a/static/kflan.css
+++ b/static/kflan.css
@@ -12,7 +12,7 @@
   height: auto;
   object-fit: cover;
   max-width: 85vw;
-  /* min-width: 55%; */
+
   
 }
 

--- a/static/kflan.css
+++ b/static/kflan.css
@@ -11,9 +11,7 @@
   max-height: 25vh;
   height: auto;
   object-fit: cover;
-  max-width: 85vw;
-
-  
+  max-width: 85vw; 
 }
 
 .header h1 {

--- a/static/kflan.css
+++ b/static/kflan.css
@@ -8,11 +8,11 @@
 }
 
 .header img {
-  max-height: 30vh;
+  max-height: 25vh;
   height: auto;
   object-fit: cover;
   max-width: 85vw;
-  min-width: 55%;
+  /* min-width: 55%; */
   
 }
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/81708938-589e-4d85-bcfa-ad3601cdd0bc)

Example with different device sizes...
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/0a512461-6ab8-4091-a1f3-a152f9be2519">
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/6fa171f5-f19f-4b23-825f-b646d634a229">
<img width="816" alt="image" src="https://github.com/user-attachments/assets/59d8a707-59cb-461f-9726-9f9326c67d1e">

I do believe the issue laid with the min width.